### PR TITLE
Fixed deriveSchema generating false positives

### DIFF
--- a/bin/deriveSchema.js
+++ b/bin/deriveSchema.js
@@ -38,7 +38,7 @@ const virtualColsQuery = (tableName, typeCase) => {
 		WHERE pg_catalog.pg_function_is_visible(p.oid)
 			AND n.nspname <> 'pg_catalog'
 			AND n.nspname <> 'information_schema'
-			AND pg_catalog.pg_get_function_arguments(p.oid) = 't ${tableName}';
+			AND pg_catalog.pg_get_function_arguments(p.oid) like '_ ${tableName}';
 	`;
 };
 

--- a/bin/deriveSchema.js
+++ b/bin/deriveSchema.js
@@ -38,7 +38,7 @@ const virtualColsQuery = (tableName, typeCase) => {
 		WHERE pg_catalog.pg_function_is_visible(p.oid)
 			AND n.nspname <> 'pg_catalog'
 			AND n.nspname <> 'information_schema'
-			AND pg_catalog.pg_get_function_arguments(p.oid) like '%${tableName}';
+			AND pg_catalog.pg_get_function_arguments(p.oid) = 't ${tableName}';
 	`;
 };
 


### PR DESCRIPTION
# Summary
GAN-1400 was a direct result of this bug. The `admin` function was being associated with the `users` table because while detecting virtual tables, we do a fuzzy match instead of an exact match. So instead of associating `admin` with `workspace_users` alone, we associate it with `workspace_users` and `users`. I've fixed this by using a more precise pattern match that checks for a single letter + a space + the table name (eg, "x projects", "c collections", "t workspace_users".

# Testing
If you don't want to change the `package.json` of the gannondorf repo, you can copy `bin/deriveSchema.js` from this repo into `node_modules/wellspring-orm/bin/deriveSchema.js` in your local copy of `gannondorf`. Then, either run migrations or derive the schema alone (`yarn derive-schema`) and inspect the resulting `schema.json` file. If you search for `admin`, you should only see it listed under `workspace_users`.